### PR TITLE
✨ feat: 관리자 계정 로직 구현

### DIFF
--- a/prisma/migrations/20250124132231_add_role_to_user/migration.sql
+++ b/prisma/migrations/20250124132231_add_role_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `user` ADD COLUMN `role` ENUM('ADMIN', 'USER') NOT NULL DEFAULT 'USER';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   location_id           BigInt?
   last_login            DateTime?
   status                String
+  role                  UserRole           @default(USER) // 추가된 필드
   comments              Comment[]
   logs                  Log[]
   magazine_bookmarks    MagazineBookmark[]
@@ -367,4 +368,9 @@ enum SocialProvider {
 enum user_login_type {
   EMAIL
   KAKAO
+}
+
+enum UserRole {
+  ADMIN
+  USER
 }

--- a/src/controllers/admin.controller.ts
+++ b/src/controllers/admin.controller.ts
@@ -1,0 +1,43 @@
+import { Router, Request, Response } from 'express';
+import { AdminService } from '../services/admin.service';
+import { AdminCreateDto, AdminLoginDto, PasswordUpdateDto } from '../dtos/admin.dto';
+import { authenticateJWT } from '../middlewares/authenticateJWT';
+
+export class AdminController {
+  private adminService: AdminService;
+  public router: Router;
+
+  constructor() {
+    this.adminService = new AdminService();
+    this.router = Router();
+    this.initializeRoutes();
+  }
+
+  private initializeRoutes() {
+    this.router.post('/admin/create', this.createAdmin.bind(this));
+    this.router.post('/admin/login', this.loginAdmin.bind(this));
+    this.router.put('/admin/password', authenticateJWT, this.updatePassword.bind(this));
+  }
+
+  // 관리자 계정 생성
+  public async createAdmin(req: Request, res: Response): Promise<void> {
+    const data: AdminCreateDto = req.body;
+    const newAdmin = await this.adminService.createAdmin(data.email, data.password);
+    res.status(201).json({ isSuccess: true, message: '관리자 계정이 생성되었습니다.', result: newAdmin });
+  }
+
+  // 관리자 로그인
+  public async loginAdmin(req: Request, res: Response): Promise<void> {
+    const data: AdminLoginDto = req.body;
+    const tokens = await this.adminService.loginAdmin(data.email, data.password);
+    res.status(200).json({ isSuccess: true, message: '로그인 성공', result: tokens });
+  }
+
+  // 관리자 비밀번호 변경
+  public async updatePassword(req: Request, res: Response): Promise<void> {
+    const adminId = req.user?.userId;
+    const data: PasswordUpdateDto = req.body;
+    const result = await this.adminService.updatePassword(adminId, data.oldPassword, data.newPassword);
+    res.status(200).json({ isSuccess: true, message: result.message });
+  }
+}

--- a/src/dtos/admin.dto.ts
+++ b/src/dtos/admin.dto.ts
@@ -1,0 +1,14 @@
+export interface AdminCreateDto {
+    email: string;
+    password: string;
+  }
+  
+  export interface AdminLoginDto {
+    email: string;
+    password: string;
+  }
+  
+  export interface PasswordUpdateDto {
+    oldPassword: string;
+    newPassword: string;
+  }  

--- a/src/repositories/admin.repository.ts
+++ b/src/repositories/admin.repository.ts
@@ -1,0 +1,31 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export class AdminRepository {
+  // 관리자 생성
+  async createAdmin(email: string, hashedPassword: string) {
+    return await prisma.user.create({
+      data: {
+        email,
+        password: hashedPassword,
+        role: 'ADMIN', // 관리자 계정으로 설정
+      },
+    });
+  }
+
+  // 이메일로 관리자 조회
+  async findAdminByEmail(email: string) {
+    return await prisma.user.findUnique({
+      where: { email },
+    });
+  }
+
+  // 비밀번호 업데이트
+  async updatePassword(userId: number, newPassword: string) {
+    return await prisma.user.update({
+      where: { user_id: userId },
+      data: { password: newPassword },
+    });
+  }
+}

--- a/src/services/admin.service.ts
+++ b/src/services/admin.service.ts
@@ -1,0 +1,62 @@
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import { AdminRepository } from '../repositories/admin.repository';
+import { UnauthorizedError, ValidationError } from '../errors';
+
+export class AdminService {
+  private adminRepository: AdminRepository;
+
+  constructor() {
+    this.adminRepository = new AdminRepository();
+  }
+
+  // 관리자 생성
+  async createAdmin(email: string, password: string) {
+    const existingAdmin = await this.adminRepository.findAdminByEmail(email);
+    if (existingAdmin) {
+      throw new ValidationError('이미 존재하는 이메일입니다.');
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+    return await this.adminRepository.createAdmin(email, hashedPassword);
+  }
+
+  // 관리자 로그인
+  async loginAdmin(email: string, password: string) {
+    const admin = await this.adminRepository.findAdminByEmail(email);
+    if (!admin || admin.role !== 'ADMIN') {
+      throw new UnauthorizedError('관리자 계정이 아니거나 존재하지 않습니다.');
+    }
+
+    const isPasswordValid = await bcrypt.compare(password, admin.password!);
+    if (!isPasswordValid) {
+      throw new UnauthorizedError('비밀번호가 일치하지 않습니다.');
+    }
+
+    const token = jwt.sign(
+      { userId: admin.user_id, role: admin.role },
+      process.env.JWT_SECRET!,
+      { expiresIn: '1h' }
+    );
+
+    return { accessToken: token };
+  }
+
+  // 비밀번호 변경
+  async updatePassword(userId: number, oldPassword: string, newPassword: string) {
+    const admin = await this.adminRepository.findAdminByEmail(userId.toString());
+    if (!admin || admin.role !== 'ADMIN') {
+      throw new UnauthorizedError('관리자 계정이 아니거나 존재하지 않습니다.');
+    }
+
+    const isPasswordValid = await bcrypt.compare(oldPassword, admin.password!);
+    if (!isPasswordValid) {
+      throw new ValidationError('기존 비밀번호가 일치하지 않습니다.');
+    }
+
+    const hashedNewPassword = await bcrypt.hash(newPassword, 10);
+    await this.adminRepository.updatePassword(userId, hashedNewPassword);
+
+    return { message: '비밀번호가 성공적으로 변경되었습니다.' };
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#57

## 📝작업 내용

Prisma 스키마 수정

User 모델에 role 필드 추가 (enum: USER, ADMIN)
기본값을 USER로 설정하여 관리자 계정을 명확히 구분
관리자 계정 생성 API

/api/v1/admin/create
시스템 관리자가 직접 관리자 계정을 생성할 수 있도록 로직 구현
관리자 로그인 API

/api/v1/admin/login
이메일 및 비밀번호 기반 로그인 구현
JWT 발급 (role 정보 포함)
관리자 비밀번호 변경 API

/api/v1/admin/password
JWT 인증 기반으로 비밀번호를 안전하게 변경 가능
Swagger 문서 업데이트

관리자 관련 API 추가
입력 데이터 형식 및 응답 형식 명시

### 스크린샷 (선택)
<img width="1137" alt="스크린샷 2025-01-24 오후 11 37 18" src="https://github.com/user-attachments/assets/418ce04f-3fd2-4d74-9533-06d67940b460" />
<img width="1136" alt="스크린샷 2025-01-24 오후 11 31 31" src="https://github.com/user-attachments/assets/1aca8b0c-d83f-4b21-85bd-51ec3e4777db" />
<img width="1137" alt="스크린샷 2025-01-24 오후 11 37 21" src="https://github.com/user-attachments/assets/ad17b22d-7129-4390-b5aa-64e465a5eb3b" />
<img width="1136" alt="스크린샷 2025-01-25 오전 12 00 02" src="https://github.com/user-attachments/assets/b258c761-2bef-4363-9904-0935fe52c8e3" />



## 💬리뷰 요구사항(선택)

관리자 계정 생성 및 로그인 로직의 보안 강화를 위한 추가 검토 요청
JWT 토큰 유효 시간 및 추가적인 보안 처리
updatePassword 메서드 내 예외 처리 로직 개선 가능성 검토
인증 미들웨어(authenticateJWT)에서 role 기반 인증 처리 방식에 대한 피드백 요청
