### PR TITLE
🐛 Fix: 해시태그가 정상적으로 표시되지 않는 문제 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@eslint/js": "^9.17.0",
         "@tsconfig/node20": "^20.1.4",
         "@types/axios": "^0.14.4",
+        "@types/bcrypt": "^5.0.2",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/express-session": "^1.18.1",
@@ -884,6 +885,16 @@
       "license": "MIT",
       "dependencies": {
         "axios": "*"
+      }
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
+      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@eslint/js": "^9.17.0",
     "@tsconfig/node20": "^20.1.4",
     "@types/axios": "^0.14.4",
+    "@types/bcrypt": "^5.0.2",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/express-session": "^1.18.1",

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -62,6 +62,7 @@ export class UserRepository {
       return await this.prisma.user.create({
         data: {
           email: userData.email,
+          password: userData.password,
           nickname: userData.nickname,
           provider: userData.provider,
           providerId: userData.providerId,


### PR DESCRIPTION
## #️⃣연관된 이슈

#78 - 팁 생성 시 해시태그가 정상적으로 조회되지 않는 문제 수정

## 📝작업 내용

팁을 생성할 때 해시태그가 API 응답에서 정상적으로 표시되지 않는 문제를 해결했습니다.

Prisma에서 hashtags 데이터를 조회할 때 include 설정 추가
API 응답에서 hashtags 데이터를 변환하여 반환하도록 수정

📌 주요 변경 사항

* Prisma에서 hashtags 포함하여 조회 (getTipById)

```
async getTipById(tipId: number) {
  return await prisma.tip.findUnique({
    where: { tips_id: tipId },
    include: {
      hashtags: { include: { hashtag: true } }, // ✅ 해시태그 정보 포함
    },
  });
}
```
* API 응답에서 hashtags 변환 (map() 적용)

```
return {
  ...newTip,
  hashtags: newTip.hashtags.map((h) => ({
    hashtag_id: h.hashtag.hashtag_id,
    name: h.hashtag.name,
  })),
};
```

### 스크린샷 (선택)
<img width="1138" alt="스크린샷 2025-02-01 오후 11 28 49" src="https://github.com/user-attachments/assets/38c9a6ad-678b-4bf5-82cf-4a090d816672" />
<img width="1138" alt="스크린샷 2025-02-01 오후 11 28 53" src="https://github.com/user-attachments/assets/605cd339-4ef0-4234-8c80-cdaf388b38e7" />
<img width="1149" alt="스크린샷 2025-02-01 오후 11 28 41" src="https://github.com/user-attachments/assets/5487c54a-15af-476c-bfff-4e11847b0f27" />