### PR TITLE
✨ feat: 댓글 전체,상세 조회

### DIFF
--- a/src/controllers/community.controller.ts
+++ b/src/controllers/community.controller.ts
@@ -50,6 +50,15 @@ export class CommunityController {
         this.getSavedTips.bind(this)
       );
     //유저별 꿀팁 북마크 조회 
+    this.router.get('/comments', 
+      authenticateJWT,
+      this.getAllComments.bind(this)
+    ); // 전체 댓글 조회
+
+    this.router.get('/comments/:commentId',
+      authenticateJWT,
+      this.getCommentById.bind(this)
+    ); // 특정 댓글 상세 조회
     
   }
 
@@ -465,6 +474,101 @@ private async toggleBookmark(req: Request, res: Response, next: NextFunction) {
     next(error);
   }
 }
+
+/**
+   * @swagger
+   * /api/v1/comments:
+   *   get:
+   *     summary: "전체 댓글 조회"
+   *     description: "인증된 사용자가 모든 댓글을 조회합니다."
+   *     tags:
+   *       - Communities
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: page
+   *         required: false
+   *         schema:
+   *           type: integer
+   *           default: 1
+   *         description: "페이지 번호"
+   *       - in: query
+   *         name: limit
+   *         required: false
+   *         schema:
+   *           type: integer
+   *           default: 10
+   *         description: "한 페이지당 댓글 개수"
+   *     responses:
+   *       200:
+   *         description: "전체 댓글 조회 성공"
+   *       401:
+   *         description: "인증 실패"
+   */
+public async getAllComments(req: Request, res: Response, next: NextFunction) {
+  try {
+    const page = parseInt(req.query.page as string) || 1;
+    const limit = parseInt(req.query.limit as string) || 10;
+
+    const comments = await this.communityService.getAllComments(page, limit);
+    res.status(StatusCodes.OK).json({
+      isSuccess: true,
+      message: '전체 댓글 조회 성공',
+      result: comments,
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+  /**
+   * @swagger
+   * /api/v1/comments/{commentId}:
+   *   get:
+   *     summary: "댓글 상세 조회"
+   *     description: "인증된 사용자가 특정 댓글의 상세 정보를 조회합니다."
+   *     tags:
+   *       - Communities
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: commentId
+   *         required: true
+   *         schema:
+   *           type: integer
+   *         description: "조회할 댓글의 ID"
+   *     responses:
+   *       200:
+   *         description: "댓글 조회 성공"
+   *       401:
+   *         description: "인증 실패"
+   *       404:
+   *         description: "댓글을 찾을 수 없음"
+   */
+  public async getCommentById(req: Request, res: Response, next: NextFunction) {
+    try {
+      const commentId = parseInt(req.params.commentId, 10);
+      if (!commentId) {
+        return res.status(StatusCodes.BAD_REQUEST).json({ message: '유효한 댓글 ID가 필요합니다.' });
+      }
+
+      const comment = await this.communityService.getCommentById(commentId);
+      if (!comment) {
+        return res.status(StatusCodes.NOT_FOUND).json({ message: '댓글을 찾을 수 없습니다.' });
+      }
+
+      res.status(StatusCodes.OK).json({
+        isSuccess: true,
+        message: '댓글 조회 성공',
+        result: comment,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
 
 }
 

--- a/src/repositories/community.repository.ts
+++ b/src/repositories/community.repository.ts
@@ -28,29 +28,6 @@ export class CommunityRepository {
     });
   }
 
-// 댓글 ID로 댓글 조회
-public async getCommentById(commentId: number) {
-  return await prisma.comment.findUnique({
-    where: { comment_id: commentId },
-    include: {
-      user: {
-        select: {
-          user_id: true,
-          nickname: true,
-          profile_image_url: true,
-        },
-      }, // 댓글 작성자 정보 포함 (필요시)
-      tips: {
-        select: {
-          tips_id: true,
-          title: true,
-        },
-      }, // 관련된 팁 정보 포함 (필요시)
-    },
-  });
-
-}
-
 
   // 댓글 작성
   public async commentOnTip(userId: number, tipId: number, comment: string) {
@@ -157,6 +134,52 @@ public async getCommentById(commentId: number) {
                 media_type: true,
               },
             },
+          },
+        },
+      },
+    });
+  }
+
+   // ✅ 전체 댓글 조회 (페이지네이션 적용)
+   public async getAllComments(skip: number, take: number) {
+    return await prisma.comment.findMany({
+      skip,
+      take,
+      orderBy: { created_at: 'desc' }, // 최신 댓글 순으로 정렬
+      include: {
+        user: {
+          select: {
+            user_id: true,
+            nickname: true,
+            profile_image_url: true,
+          },
+        },
+        tips: {
+          select: {
+            tips_id: true,
+            title: true,
+          },
+        },
+      },
+    });
+  }
+
+  // ✅ 특정 댓글 상세 조회
+  public async getCommentById(commentId: number) {
+    return await prisma.comment.findUnique({
+      where: { comment_id: commentId },
+      include: {
+        user: {
+          select: {
+            user_id: true,
+            nickname: true,
+            profile_image_url: true,
+          },
+        },
+        tips: {
+          select: {
+            tips_id: true,
+            title: true,
           },
         },
       },

--- a/src/services/community.service.ts
+++ b/src/services/community.service.ts
@@ -170,4 +170,23 @@ export class CommunityService {
       createdAt: save.tips.created_at,
     }));
   }
+
+  // ✅ 전체 댓글 조회 (페이지네이션 적용)
+  public async getAllComments(page: number, limit: number) {
+
+    if (page < 1 || limit < 1) {
+      throw new ValidationError('페이지 번호와 개수는 1 이상이어야 합니다.',null);
+    }
+    const skip = (page - 1) * limit;
+    return await this.communityRepository.getAllComments(skip, limit);
+  }
+
+  // ✅ 특정 댓글 상세 조회
+  public async getCommentById(commentId: number) {
+    if (!commentId || isNaN(commentId)) {
+      throw new ValidationError('유효한 댓글 ID가 필요합니다.',null);
+    }
+
+    return await this.communityRepository.getCommentById(commentId);
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#131 

## 📝작업 내용

-전체 댓글 조회 (페이지네이션 포함)

GET /api/v1/comments?page={page}&limit={limit}
페이지 단위로 댓글을 조회할 수 있도록 구현.
page와 limit이 1 미만일 경우 예외 처리.

-특정 댓글 상세 조회

GET /api/v1/comments/{commentId}
특정 댓글 ID를 기반으로 상세 정보를 조회.
유효하지 않은 commentId 요청 시 예외 처리.

