### PR TITLE
✨ Feat: 챗봇 채팅 세션별 대화 저장 및 조회 기능 구현

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,8 @@ model User {
   last_login            DateTime?
   status                String
   role                  UserRole           @default(USER)
+  chat_sessions         ChatSession[] 
+  chat_histories        ChatHistory[]
   hashtags              UserHashtag[]
   comments              Comment[]
   logs                  Log[]
@@ -359,6 +361,35 @@ model UserActivityType {
   logs                  Log[]
 
   @@map("user_activity_type")
+}
+
+model ChatSession {
+  session_id   Int           @id @default(autoincrement()) 
+  user_id      Int?          
+  created_at   DateTime      @default(now()) 
+  title        String?       // 채팅 세션 이름 (예: "청년 정책 상담")
+  
+  user         User?         @relation(fields: [user_id], references: [user_id])
+  chat_histories ChatHistory[]
+  
+  @@index([user_id], map: "chat_session_user_id_fkey")
+  @@map("chat_session")
+}
+
+model ChatHistory {
+  chat_id   Int      @id @default(autoincrement())
+  session_id  Int          // ✅ 각 채팅이 특정 세션에 속하도록 설정
+  user_id   Int?     // 로그인된 사용자 ID (비회원이면 null)
+  question  String
+  answer    String @db.Text
+  created_at DateTime @default(now())
+
+  session   ChatSession  @relation(fields: [session_id], references: [session_id], onDelete: Cascade)
+  user      User?    @relation(fields: [user_id], references: [user_id], onDelete: Cascade) // ✅ 관계 수정
+
+  @@index([session_id], map: "chat_history_session_id_fkey")
+  @@index([user_id], map: "chat_history_user_id_fkey")
+  @@map("chat_history")
 }
 
 enum MediaType {

--- a/src/controllers/chatbot.controller.ts
+++ b/src/controllers/chatbot.controller.ts
@@ -8,19 +8,21 @@ export class ChatbotController {
   constructor() {
     this.router = Router();
     this.chatbotService = new ChatbotService();
-    this.initializeRoutes(); // 이니셜라이즈 함수 호출
+    this.initializeRoutes();
   }
 
   private initializeRoutes() {
-    this.router.post('/chat', this.askChatbot.bind(this));
+    this.router.post('/chat', this.askChatbot.bind(this)); // ✅ 질문 시 자동으로 세션 생성됨
+    this.router.get('/chat/sessions', this.getChatSessions.bind(this)); // ✅ 사이드바 목록 조회
+    this.router.get('/chat/history/:sessionId', this.getChatHistory.bind(this)); // ✅ 특정 세션 대화 조회
   }
 
   /**
    * @swagger
    * /api/v1/chat:
    *   post:
-   *     summary: AI 챗봇과 대화
-   *     description: AI 챗봇에게 질문을 입력하면 답변을 반환합니다.
+   *     summary: AI 챗봇과 대화 (자동 세션 생성)
+   *     description: AI 챗봇에게 질문을 입력하면 답변을 반환합니다. 첫 질문이면 자동으로 새로운 채팅 세션을 생성합니다.
    *     tags:
    *       - Chatbot
    *     requestBody:
@@ -33,7 +35,10 @@ export class ChatbotController {
    *               question:
    *                 type: string
    *                 example: "1인 가구를 위한 정책은 뭐가 있나요?"
-   *                 description: "사용자가 챗봇에게 묻고 싶은 질문"
+   *               sessionId:
+   *                 type: integer
+   *                 example: 42
+   *                 description: "기존 채팅 세션 ID (없으면 새로 생성됨)"
    *     responses:
    *       200:
    *         description: 챗봇의 응답을 반환합니다.
@@ -42,32 +47,86 @@ export class ChatbotController {
    *             schema:
    *               type: object
    *               properties:
+   *                 sessionId:
+   *                   type: integer
    *                 answer:
    *                   type: string
-   *                   example: "1인 가구를 위한 정책으로는 청년 월세 지원, 교통비 할인 등이 있습니다."
-   *       400:
-   *         description: 잘못된 요청 (질문이 입력되지 않음)
-   *       500:
-   *         description: 서버 오류 발생
    */
   private async askChatbot(req: Request, res: Response) {
     try {
-      const { question } = req.body;
+      let { question, sessionId } = req.body;
       if (!question) {
         return res.status(400).json({ message: '질문을 입력해주세요.' });
       }
 
-      const answer = await this.chatbotService.getChatbotResponse(question);
-      return res.json({ answer });
+      const userId = req.user?.userId || null;
+
+      // ✅ sessionId가 없으면 자동으로 새 세션 생성
+      if (!sessionId) {
+        sessionId = await this.chatbotService.createChatSession(
+          userId,
+          '새로운 채팅'
+        );
+      }
+
+      const answer = await this.chatbotService.getChatbotResponse(
+        question,
+        sessionId,
+        userId
+      );
+      return res.json({ sessionId, answer });
     } catch (error) {
       console.error('Chatbot Error:', error);
       return res.status(500).json({ message: '서버 오류가 발생했습니다.' });
     }
   }
 
-  public getRouter() {
-    return this.router;
+  /**
+   * @swagger
+   * /api/v1/chat/sessions:
+   *   get:
+   *     summary: 채팅 세션 목록 조회
+   *     description: 사용자의 채팅 세션 목록을 조회합니다. (사이드바에서 표시)
+   *     tags:
+   *       - Chatbot
+   */
+  private async getChatSessions(req: Request, res: Response) {
+    try {
+      const userId = req.user?.userId;
+      if (!userId) {
+        return res.status(403).json({ message: '로그인이 필요합니다.' });
+      }
+
+      const sessions = await this.chatbotService.getChatSessions(userId);
+      return res.json(sessions);
+    } catch (error) {
+      console.error('Session list error:', error);
+      return res
+        .status(500)
+        .json({ message: '세션 목록을 불러오는데 실패했습니다.' });
+    }
+  }
+
+  /**
+   * @swagger
+   * /api/v1/chat/history/{sessionId}:
+   *   get:
+   *     summary: 특정 세션의 채팅 기록 조회
+   */
+  private async getChatHistory(req: Request, res: Response) {
+    try {
+      const sessionId = parseInt(req.params.sessionId, 10);
+      if (!sessionId) {
+        return res.status(400).json({ message: '세션 ID가 필요합니다.' });
+      }
+
+      const chatHistory = await this.chatbotService.getChatHistory(sessionId);
+      return res.json(chatHistory);
+    } catch (error) {
+      console.error('Chat history error:', error);
+      return res
+        .status(500)
+        .json({ message: '채팅 기록을 불러오는데 실패했습니다.' });
+    }
   }
 }
-
-export default new ChatbotController().getRouter();

--- a/src/services/chatbot.service.ts
+++ b/src/services/chatbot.service.ts
@@ -1,20 +1,62 @@
+import { PrismaClient } from '@prisma/client';
 import openai from '../config/openai.config';
 
+const prisma = new PrismaClient();
+
 export class ChatbotService {
-  async getChatbotResponse(question: string): Promise<string> {
+  // ✅ 새로운 채팅 세션 생성
+  async createChatSession(userId?: number, title: string = "새로운 채팅"): Promise<number> {
+    const session = await prisma.chatSession.create({
+      data: {
+        user_id: userId || null,
+        title,
+      },
+    });
+    return session.session_id;
+  }
+
+  // ✅ 챗봇 응답 생성 & 채팅 저장
+  async getChatbotResponse(question: string, sessionId: number, userId?: number): Promise<string> {
     try {
       const response = await openai.chat.completions.create({
-        model: 'gpt-3.5-turbo', // ✅ gpt-4 → gpt-3.5-turbo 변경
+        model: 'gpt-3.5-turbo',
         messages: [{ role: 'user', content: question }],
         temperature: 0.7,
       });
 
-      return (
-        response.choices[0]?.message?.content || '답변을 생성할 수 없습니다.'
-      );
+      const answer = response.choices[0]?.message?.content || '답변을 생성할 수 없습니다.';
+
+      // ✅ 채팅 저장
+      await prisma.chatHistory.create({
+        data: {
+          session_id: sessionId,
+          user_id: userId || null,
+          question,
+          answer,
+        },
+      });
+
+      return answer;
     } catch (error) {
       console.error('OpenAI API 오류:', error);
       return '오류가 발생했습니다. 다시 시도해주세요.';
     }
+  }
+
+  // ✅ 사용자의 채팅 세션 목록 조회
+  async getChatSessions(userId: number) {
+    return prisma.chatSession.findMany({
+      where: { user_id: userId },
+      orderBy: { created_at: 'desc' },
+      select: { session_id: true, title: true, created_at: true },
+    });
+  }
+
+  // ✅ 특정 세션의 채팅 기록 조회
+  async getChatHistory(sessionId: number) {
+    return prisma.chatHistory.findMany({
+      where: { session_id: sessionId },
+      orderBy: { created_at: 'asc' },
+    });
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

ex) #140 

## 📝작업 내용

챗봇의 대화 기록을 각 세션별로 저장 및 조회할 수 있도록 기능을 구현했습니다.
사용자가 첫 질문을 입력하면 자동으로 새로운 채팅 세션이 생성되며, 이후에는 해당 세션에 대화가 저장됩니다.
또한, 사이드바에서 기존 채팅 세션 목록을 조회하고, 특정 세션의 대화 내역을 가져올 수 있도록 API를 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- ChatSession 모델의 title 기본값을 설정하는 게 좋을까요?
- askChatbot() 함수에서 sessionId를 자동 생성하는 방식이 괜찮은지 검토 부탁드립니다.
